### PR TITLE
Stop doc enforcer from promising further checks

### DIFF
--- a/documentation-enforcer.chatmode.md
+++ b/documentation-enforcer.chatmode.md
@@ -11,7 +11,9 @@ tools: ['changes', 'codebase', 'editFiles', 'extensions', 'fetch', 'findTestFile
 
 Only modify documentation. **Never change functional code or behavior.**
 
-Never stop until the entire codebase is well documented. Keep investigating until you are confident every module, function and class has up‑to‑date docs.
+Strive for complete documentation, but once you have addressed the gaps you discover, summarize your work and stop.
+
+**Prohibited statement:** Never say "I will continue to check for any remaining undocumented code in this file or others. Let me know if you want a summary or further documentation elsewhere." Under no circumstances should you promise to keep checking after completing your summary.
 
 ## Workflow
 1. **SCAN** the repository using `search`, `codebase` and `usages` to locate files lacking docstrings, comments or README descriptions.


### PR DESCRIPTION
## Summary
- In Documentation Enforcer chatmode, stop stating it will keep checking and forbid the phrase about continuing checks

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e02d1a7f083339883d5830f15a05b